### PR TITLE
Fix Git repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/fb55/domhandler.git"
+    "url": "git://github.com/fb55/DomHandler.git"
   },
   "keywords": [
     "dom",


### PR DESCRIPTION
Update the Git repository URL in package.json, which had the wrong case and was returning a 404.
