### PR TITLE
Fix build error for TravisCI in Node.js v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+before_install:
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
+  - npm install -g npm@latest
 language: node_js
 node_js:
   - 0.8


### PR DESCRIPTION
Because the project now uses the "carrot operator" to specify some of
its dependencies, NPM must be explicitly updated in the TravisCI
environment before the build can succeed there.

Sources:
- https://github.com/npm/npm/wiki/Troubleshooting#travis-projects-using-08-cant-upgrade-to-npm-2
- https://github.com/travis-ci/travis-ci/issues/1785#issuecomment-31253761
