### PR TITLE
Add `withStartIndices` option to add `startIndex` properties to nodes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,17 @@ function DomHandler(callback, options, elementCB){
 	this.dom = [];
 	this._done = false;
 	this._tagStack = [];
+	this._parser = this._parser || null;
 }
 
 //default options
 var defaultOpts = {
-	normalizeWhitespace: false //Replace all whitespace with single spaces
+	normalizeWhitespace: false, //Replace all whitespace with single spaces
+	withStartIndices: false, //Add startIndex properties to nodes
+};
+
+DomHandler.prototype.onparserinit = function(parser){
+	this._parser = parser;
 };
 
 //Resets the handler back to starting state
@@ -35,6 +41,7 @@ DomHandler.prototype.onreset = function(){
 DomHandler.prototype.onend = function(){
 	if(this._done) return;
 	this._done = true;
+	this._parser = null;
 	this._handleCallback(null);
 };
 
@@ -59,6 +66,10 @@ DomHandler.prototype._addDomElement = function(element){
 	var previousSibling = siblings[siblings.length - 1];
 
 	element.next = null;
+
+	if(this._options.withStartIndices){
+		element.startIndex = this._parser.startIndex;
+	}
 
 	if (this._options.withDomLvl1) {
 		element.__proto__ = element.type === "tag" ? ElementPrototype : NodePrototype;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "domelementtype": "1"
   },
   "devDependencies": {
-    "htmlparser2": "3.2",
+    "htmlparser2": "3.8",
     "mocha": "1",
     "jshint": "~2.3.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -100,3 +100,6 @@ The following HTML will be used:
     }]
 }]
 ```
+
+##Option: withStartIndices
+Indicates whether a `startIndex` property will be added to nodes. When the parser is used in a non-streaming fashion, `startIndex` is an integer indicating the position of the start of the node in the document. The default value is "false".

--- a/test/cases/24-with-start-indices.json
+++ b/test/cases/24-with-start-indices.json
@@ -1,0 +1,85 @@
+{
+  "name": "withStartIndices adds correct startIndex properties",
+  "options": {"withStartIndices": true},
+  "streaming": false,
+  "html": "<!DOCTYPE html> <html> <title>The Title</title> <body class='foo'>Hello world <p></p></body> <!-- the comment --> </html> ",
+  "expected": [
+    {
+      "startIndex": 0,
+      "name": "!doctype",
+      "data": "!DOCTYPE html",
+      "type": "directive"
+    },
+    {
+      "type": "text",
+      "data": " "
+    },
+    {
+      "startIndex": 16,
+      "type": "tag",
+      "name": "html",
+      "attribs": {},
+      "parent": null,
+      "children": [
+        {
+          "startIndex": 22,
+          "type": "text",
+          "data": " "
+        },
+        {
+          "startIndex": 23,
+          "type": "tag",
+          "name": "title",
+          "attribs": {},
+          "children": [
+            {
+              "startIndex": 30,
+              "data": "The Title",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "startIndex": 47,
+          "type": "text",
+          "data": " "
+        },
+        {
+          "startIndex": 48,
+          "type": "tag",
+          "name": "body",
+          "attribs": {"class": "foo"},
+          "children": [
+            {
+              "startIndex": 66,
+              "data": "Hello world ",
+              "type": "text"
+            },
+            {
+              "startIndex": 78,
+              "type": "tag",
+              "name": "p",
+              "attribs": {},
+              "children": []
+            }
+          ]
+        },
+        {
+          "startIndex": 92,
+          "type": "text",
+          "data": " "
+        },
+        {
+          "startIndex": 93,
+          "type": "comment",
+          "data": " the comment "
+        },
+        {
+          "startIndex": 113,
+          "type": "text",
+          "data": " "
+        }
+      ]
+    }
+  ]
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,10 +35,12 @@ fs
 		var parser = new Parser(handler, test.options);
 
 		//first, try to run the test via chunks
-		for(var i = 0; i < data.length; i++){
-			parser.write(data.charAt(i));
+		if (test.streaming || test.streaming === undefined){
+			for(var i = 0; i < data.length; i++){
+				parser.write(data.charAt(i));
+			}
+			parser.done();
 		}
-		parser.done();
 
 		//then parse everything
 		parser.parseComplete(data);


### PR DESCRIPTION
Fixes #7.
Refs https://github.com/fb55/htmlparser2/pull/106
Refs https://github.com/twbs/bootlint/issues/29
