### PR TITLE
Use parser.end instead of parser.done

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ var handler = new htmlparser.DomHandler(function (error, dom) {
 });
 var parser = new htmlparser.Parser(handler);
 parser.write(rawHtml);
-parser.done();
+parser.end();
 ```
 
 Output:


### PR DESCRIPTION
While I haven't found any documentation on this, it seems the official API is to call `parser.end` in order to finish parsing rather than `parser.done`, going by [htmlparser2's README](https://github.com/fb55/htmlparser2).