### PR TITLE
Add check for elem to prevent exception if elem doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ DomHandler.prototype.onclosetag = function(){
 	
 	var elem = this._tagStack.pop();
 
-	if(this._options.withEndIndices){
+	if(this._options.withEndIndices && elem){
 		elem.endIndex = this._parser.endIndex;
 	}
 


### PR DESCRIPTION
Currently this logic throws an unhandled exception if elem doesn't exist, which breaks my app. This PR adds a check to ensure elem exists before trying to access its endIndex property.