### PR TITLE
Publish only lib folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "description": "Handler for htmlparser2 that turns pages into a dom",
     "main": "lib/index.js",
     "sideEffects": false,
+    "files": [
+      "lib"
+    ],
     "scripts": {
         "test": "jest --coverage && npm run lint",
         "coverage": "cat coverage/lcov.info | coveralls",


### PR DESCRIPTION
https://packagephobia.com/result?p=domhandler
https://unpkg.com/browse/domhandler@3.0.0/

Looks like the latest versions introduced a lot of files which should
usually should not appear in packages.

In this diff I added "files" field which filters out all not listed
files and directories.