### PR TITLE
Changes in .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+    - amd64
+    - ppc64le
 node_js:
     - lts/*
 after_success: npm run coverage


### PR DESCRIPTION
Add support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/domhandler/builds/745423152/config