### PR TITLE
refactor(index): Collect attributes ourselves

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,11 +144,21 @@ export class DomHandler {
         if (this.elementCB) this.elementCB(elem);
     }
 
-    public onopentag(name: string, attribs: { [key: string]: string }): void {
+    /** Attributes of the current element. */
+    private attribs: { [key: string]: string } = {};
+
+    public onopentagname(name: string): void {
+        this.attribs = {};
         const type = this.options.xmlMode ? ElementType.Tag : undefined;
-        const element = new Element(name, attribs, undefined, type);
+        const element = new Element(name, this.attribs, undefined, type);
         this.addNode(element);
         this.tagStack.push(element);
+    }
+
+    public onattribute(name: string, value: string): void {
+        if (!Object.prototype.hasOwnProperty.call(this.attribs, name)) {
+            this.attribs[name] = value;
+        }
     }
 
     public ontext(data: string): void {


### PR DESCRIPTION
This might be necessary in a future `htmlparser2` version to get correct starting positions for tags.