### PR TITLE
Update correct type of prop parent 

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -67,11 +67,11 @@ export class Node {
      * Same as {@link parent}.
      * [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
      */
-    get parentNode(): NodeWithChildren | null {
+    get parentNode(): Element | null {
         return this.parent;
     }
 
-    set parentNode(parent: NodeWithChildren | null) {
+    set parentNode(parent: Element | null) {
         this.parent = parent;
     }
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -17,7 +17,7 @@ const nodeTypes = new Map<ElementType, number>([
  */
 export class Node {
     /** Parent of the node */
-    parent: NodeWithChildren | null = null;
+    parent: Element | null = null;
 
     /** Previous sibling */
     prev: Node | null = null;


### PR DESCRIPTION
Hey, I've just ran into an issue. The `parent` prop is defined as `NodeWithChildren` but it has `attribs` and `name` as props. So it should be defined as an `Element`. Please look into this. If this is correct, please also inform [remarkablemark](https://github.com/remarkablemark) because we ran into this issue using his [html-react-parser](https://github.com/remarkablemark/html-react-parser).

Currently we fixed this issue with the following code:
```js
  replace: (domNode: Element) => {
      const { attribs, children, name, parent } = domNode;
      const parentAsElement = parent as Element;
      // ...
  }
```
Thanks!