### PR TITLE
Repurpose hasChildren and add isParentNode

### DIFF
--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -84,6 +84,12 @@ describe("Nodes", () => {
         expect(node.isComment(result)).toBe(false);
         expect(node.isDirective(result)).toBe(false);
         expect(node.isDocument(result)).toBe(false);
+        expect(node.isParentNode(result)).toBe(true);
+    });
+
+    it("should not detect children when there are none", () => {
+        const result = parse("<div foo=bar>").children[0];
+        expect(node.hasChildren(result)).toBe(false);
     });
 
     it("should support using tagged types", () => {

--- a/src/node.ts
+++ b/src/node.ts
@@ -393,13 +393,27 @@ export function isDocument(node: Node): node is Document {
 }
 
 /**
+ * Checks if `node` is a parent node.
+ *
+ * @param node Node to check.
+ * @returns `true` if the node is a parent node.
+ */
+export function isParentNode(node: Node): node is ParentNode {
+    return (
+        node.type === ElementType.Root ||
+        node.type === ElementType.Tag ||
+        node.type === ElementType.CDATA
+    );
+}
+
+/**
  * Checks if `node` has children.
  *
  * @param node Node to check.
  * @returns `true` if the node has children.
  */
 export function hasChildren(node: Node): node is ParentNode {
-    return Object.prototype.hasOwnProperty.call(node, "children");
+    return isParentNode(node) && node.children.length > 0;
 }
 
 /**


### PR DESCRIPTION
The way `hasChildren` is written is misleading, e.g. it will return true for `<div></div>` because it only checks if the `children` property exists on the node.

I refactored `hasChildren` to return true if the node actually has children`, e.g. `<div></div>` will return false but `<div>foo</div>` will return true.

I also added another function, `isParentNode`, which serves the same purpose as the former `hasChildren`, though it checks the node's type rather than it's prototype.