### PR TITLE
Add DOM nodeName aliases

### DIFF
--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -72,6 +72,7 @@ describe("Nodes", () => {
         class Doctype extends node.Node {
             type = ElementType.Doctype;
             nodeType = Number.NaN;
+            nodeName = "doctype";
         }
         const element = new Doctype();
         expect(() => element.cloneNode()).toThrow(
@@ -105,6 +106,22 @@ describe("Nodes", () => {
         setQuirks(parent);
 
         expect(parent).toHaveProperty("x-mode", "no-quirks");
+    });
+
+    it("should expose DOM nodeName aliases", () => {
+        const text = new node.Text("text");
+        const comment = new node.Comment("comment");
+        const cdata = new node.CDATA([text]);
+        const document = new node.Document([cdata]);
+        const directive = new node.ProcessingInstruction("xml", "?xml");
+        const element = new node.Element("div", {});
+
+        expect(text.nodeName).toBe("#text");
+        expect(comment.nodeName).toBe("#comment");
+        expect(cdata.nodeName).toBe("#cdata-section");
+        expect(document.nodeName).toBe("#document");
+        expect(directive.nodeName).toBe("xml");
+        expect(element.nodeName).toBe("div");
     });
 });
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -80,6 +80,12 @@ export abstract class Node {
      */
     abstract readonly nodeType: number;
 
+    /**
+     * [DOM spec](https://dom.spec.whatwg.org/#dom-node-nodename)-compatible
+     * alias.
+     */
+    abstract readonly nodeName: string;
+
     // Read-write aliases for properties
 
     /**
@@ -164,6 +170,10 @@ export class Text extends DataNode {
     get nodeType(): 3 {
         return 3;
     }
+
+    get nodeName(): "#text" {
+        return "#text";
+    }
 }
 
 /**
@@ -174,6 +184,10 @@ export class Comment extends DataNode {
 
     get nodeType(): 8 {
         return 8;
+    }
+
+    get nodeName(): "#comment" {
+        return "#comment";
     }
 }
 
@@ -191,6 +205,10 @@ export class ProcessingInstruction extends DataNode {
 
     override get nodeType(): 1 {
         return 1;
+    }
+
+    get nodeName(): string {
+        return this.name;
     }
 
     /** If this is a doctype, the document type name (parse5 only). */
@@ -250,6 +268,10 @@ export class CDATA extends NodeWithChildren {
     get nodeType(): 4 {
         return 4;
     }
+
+    get nodeName(): "#cdata-section" {
+        return "#cdata-section";
+    }
 }
 
 /**
@@ -260,6 +282,10 @@ export class Document extends NodeWithChildren {
 
     get nodeType(): 9 {
         return 9;
+    }
+
+    get nodeName(): "#document" {
+        return "#document";
     }
 
     /** [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks) (parse5 only). */
@@ -311,6 +337,10 @@ export class Element extends NodeWithChildren {
 
     get nodeType(): 1 {
         return 1;
+    }
+
+    get nodeName(): string {
+        return this.name;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a DOM-compatible `nodeName` alias to domhandler node classes.

`domhandler` already exposes several DOM-style aliases such as `nodeType`, `parentNode`, `childNodes`, `tagName`, and `attributes`. This adds the commonly used `nodeName` property for text, comment, CDATA, document, processing instruction, and element nodes without changing the existing internal node model.

This is related to #684.

## Validation

- `vitest run`
- `tsc --noEmit -p tsconfig.eslint.json`
- `biome check src/node.ts src/node.spec.ts`
- `eslint src/node.ts src/node.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOM-style `nodeName` support across node types, including text, comment, CDATA, document, processing instruction, and element nodes.
  * Node names now return familiar DOM values like `#text`, `#comment`, `#document`, and tag or target names where applicable.

* **Bug Fixes**
  * Improved error messages when cloning unsupported node types so they now report the expected node name.

* **Tests**
  * Added coverage for `nodeName` aliases and updated cloning-related expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->